### PR TITLE
Update lineComment symbol for vscode extension configuration

### DIFF
--- a/tooling/vscode/language-configuration.json
+++ b/tooling/vscode/language-configuration.json
@@ -1,7 +1,7 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "//"
+        "lineComment": "::"
     },
     // symbols used as brackets
     "brackets": [


### PR DESCRIPTION
This updates the lineComment to `::` instead of `//` such that comment
shortcuts will use the Doc comment style by default.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>