### PR TITLE
Revert "Update lineComment symbol for vscode extension configuration"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,11 @@
 version: 2.1
 
 workflows:
-  build: { jobs: [build] }
-  tooling-vscode-publish: { jobs: [tooling-vscode-publish] }
+  build:
+    jobs: [build]
+  tooling-vscode-publish:
+    jobs: [tooling-vscode-publish]
+    branches: { only: [master] }
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,8 @@
 version: 2.1
 
 workflows:
-  build:
-    jobs: [build]
-  tooling-vscode-publish:
-    jobs: [tooling-vscode-publish]
-    branches: { only: [master] }
+  build: { jobs: [build] }
+  tooling-vscode-publish: { jobs: [tooling-vscode-publish] }
 
 jobs:
   build:
@@ -20,6 +17,7 @@ jobs:
           command: make ci
 
   tooling-vscode-publish:
+    branches: { only: [master] }
     executor: node
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,13 @@
 version: 2.1
 
 workflows:
-  build: { jobs: [build] }
-  tooling-vscode-publish: { jobs: [tooling-vscode-publish] }
+  build:
+    jobs:
+      - build
+  tooling-vscode-publish:
+    jobs:
+      - tooling-vscode-publish:
+          filters: { branches: { only: [master] } }
 
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,6 @@ jobs:
           command: make ci
 
   tooling-vscode-publish:
-    branches: { only: [master] }
     executor: node
     steps:
       - checkout

--- a/tooling/vscode/language-configuration.json
+++ b/tooling/vscode/language-configuration.json
@@ -1,7 +1,7 @@
 {
     "comments": {
         // symbol used for single line comment. Remove this entry if your language does not support line comments
-        "lineComment": "::"
+        "lineComment": "//"
     },
     // symbols used as brackets
     "brackets": [

--- a/tooling/vscode/package.json
+++ b/tooling/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "mare",
 	"displayName": "Mare Language",
 	"description": "Support for the Mare programming language.",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"publisher": "mare-lang",
 	"engines": {
 		"vscode": "^1.35.0"


### PR DESCRIPTION
As discussed in that ticket, using `//` makes more sense as the `lineComment` symbol.