### PR TITLE
Add library links

### DIFF
--- a/src/mare/compiler/binary.cr
+++ b/src/mare/compiler/binary.cr
@@ -39,6 +39,11 @@ class Mare::Compiler::Binary
       -fuse-ld=lld -rdynamic -static -fpic
       -lc -pthread -ldl -latomic -lexecinfo
     }
+
+    ctx.link_libraries.each do |x|
+      link_args << "-l" + x
+    end
+
     link_args << obj_filename
     link_args << "-o" << "main" # TODO: customizable output binary filename
 

--- a/src/mare/compiler/context.cr
+++ b/src/mare/compiler/context.cr
@@ -20,6 +20,8 @@ class Mare::Compiler::Context
   getter serve_definition
   getter serve_hover
 
+  getter link_libraries
+
   def initialize
     @program = Program.new
     @stack = [] of Interpreter
@@ -42,6 +44,7 @@ class Mare::Compiler::Context
     @refer_type = ReferType::Pass.new
     @serve_definition = ServeDefinition.new
     @serve_hover = ServeHover.new
+    @link_libraries = Set(String).new
   end
 
   def compile_library(*args)

--- a/src/mare/compiler/import.cr
+++ b/src/mare/compiler/import.cr
@@ -32,7 +32,7 @@ class Mare::Compiler::Import
 
   def run_for_library(ctx, library)
     # For each import statement found in the library, resolve it.
-    library.imports.each do |import|
+    library.imports.each.with_index do |import, i|
       # Skip imports that have already been resolved.
       next if @libraries_by_import.has_key?(import)
 
@@ -41,6 +41,14 @@ class Mare::Compiler::Import
       relative_path = import.ident
       raise NotImplementedError.new(import.ident.to_a) \
         unless relative_path.is_a?(AST::LiteralString)
+
+      # Check if we are linking library
+      if (path = relative_path.value).starts_with? "lib:"
+        path = path[4..path.size]
+        ctx.link_libraries << path
+        library.imports.delete_at(i)
+        next
+      end
 
       # Based on the source file that the import statement was declared in
       # and the relative path mentioned in the import statement itself,


### PR DESCRIPTION
I didn't find info how to link libraries to the jit evaluation. So we cant use "lib:xxx" in run and eval modes.