### PR TITLE
Add method to build Source::Pos from an offset

### DIFF
--- a/spec/compiler/source_pos_spec.cr
+++ b/spec/compiler/source_pos_spec.cr
@@ -1,0 +1,32 @@
+describe Mare::Source::Pos do
+  it "builds from a source and offset" do
+    source = Mare::Source.new_example <<-SOURCE
+    :class Foo
+      :prop a A
+      :new (@a)
+      :fun string String
+        if (A <: String) (@a | "...")
+
+    SOURCE
+    
+    # Point to the F character on line 1
+    pos = Mare::Source::Pos.point(source, 7)
+
+    pos.start.should eq(7)
+    pos.finish.should eq(7)
+    pos.line_start.should eq(0)
+    pos.line_finish.should eq(10)
+    pos.row.should eq(0)
+    pos.col.should eq(7)
+
+    # Point to the @ character on line 3
+    pos = Mare::Source::Pos.point(source, 31)
+
+    pos.start.should eq(31)
+    pos.finish.should eq(31)
+    pos.line_start.should eq(23)
+    pos.line_finish.should eq(34)
+    pos.row.should eq(2)
+    pos.col.should eq(8)
+  end
+end

--- a/src/mare/source.cr
+++ b/src/mare/source.cr
@@ -63,6 +63,22 @@ struct Mare::Source::Pos
     new(source, start, start, line_start, line_finish, row, col)
   end
 
+  def self.point(source : Source, offset : Int32)
+    line_start = 0
+    line_finish = source.content.index("\n") || source.content.size
+    row = 0
+
+    while line_finish < offset
+      line_start = line_finish + 1
+      line_finish = source.content.index("\n", line_start) || source.content.size
+      row += 1
+    end
+
+    col = offset - line_start
+
+    new(source, offset, offset, line_start, line_finish, row, col)
+  end
+
   def self.index_range(source : Source, new_start : Int32, new_finish : Int32)
     # TODO: dedup with similar logic in span and subset
     new_row = 0


### PR DESCRIPTION
## Why do we want this?

This is the first step towards building a better LSP diagnostic response, but first a bit of background.

As of recently, when Mare compiles it will add all the errors it finds along the way in the `@context.errors` variable. One of the  errors we need to catch is `Pegmatite::Pattern::MatchError`, thrown when parsing files. In order for us to wrap this in an `Error` we need to construct a `Source::Pos` pointing to where this happens in the source, but `Pegmatite` only reports the byte offset[1] where parsing fails, not a row and column.

[1] We might need an enhancement for `Pegmatite::Pattern::MatchError` to _actually_ read the offset attribute, but this PR assumes it exists.

## Why did I do it this way?

I first set off to just calculate the `row` and `col` given the offset (to call `point(source, row, col)` afterwards), but I later noticed that given the way I walked the source, if I just renamed my variables I would already have the `line_start` and `line_finish` values.

## Test output

Since (I think) we don't have a CI, here's the passing spec:
```bash
$ target=spec/compiler/source_pos_spec.cr make test.narrow
docker exec -ti mare-dev make target="spec/compiler/source_pos_spec.cr" extra_args="" test.narrow.inner
crystal spec spec/spec_helper.cr "spec/compiler/source_pos_spec.cr"
.

Finished in 263 microseconds
1 examples, 0 failures, 0 errors, 0 pending
```