### PR TITLE
Use new case syntax when possible

### DIFF
--- a/docs/intro-vs-pony.md
+++ b/docs/intro-vs-pony.md
@@ -260,6 +260,21 @@ Now let's look at an example of `case` used with the subtype check operator:
     )
 ```
 
+An alternative syntax for `case` is available when the variable and operator are the same in every conditional part:
+
+```mare
+:primitive Example
+  :fun thing_to_number(thing Any'box) I64
+    case thing <: (
+    | Numeric | thing.i64
+    | String  | try (thing.parse_i64! | -1)
+    | None    | 0
+    | -1
+    )
+```
+
+Note that a final part with no condition is also supported.
+
 #### Try
 
 A `try` macro has just one term: the block to execute with a landing pad to "catch" any errors it might raise.

--- a/packages/collections/map.mare
+++ b/packages/collections/map.mare
@@ -75,8 +75,8 @@
       index = @_search(key)
       entry = @_array[index]!
 
-      case (
-      | entry <: _KV(K, V) | entry.value = --value
+      case entry <: (
+      | _KV(K, V) | entry.value = --value
       |
         @_array[index]! = _KV(K, V).new(--key, --value)
         @_size += 1
@@ -121,14 +121,14 @@
       @_array.each_with_index -> (entry, i |
         entry = @_array[idx]!
 
-        case (
-        | entry <: @->(_KV(K, V)) |
+        case entry <: (
+        | @->(_KV(K, V)) |
           if H.equal(key, entry.key) (
             result_idx = idx
             found = True
             error! // TODO: use early return instead of error!
           )
-        | entry <: _MapEmpty |
+        | _MapEmpty |
           if (idx_del > mask) (
             result_idx = idx
           |
@@ -136,7 +136,7 @@
           )
           found = False
           error!
-        | entry <: _MapDeleted |
+        | _MapDeleted |
           if (idx_del > mask) (
             idx_del = idx
           )

--- a/packages/collections/ordered_map.mare
+++ b/packages/collections/ordered_map.mare
@@ -116,8 +116,8 @@
       index = @_search(key)
       entry = @_array[index]!
 
-      case (
-      | entry <: @->(_KVBA(K, V)) |
+      case entry <: (
+      | @->(_KVBA(K, V)) |
         entry.value = --value
 
         // If this entry is not already the head, we will make it the new head.
@@ -176,14 +176,14 @@
       @_array.each_with_index -> (entry, i |
         entry = @_array[idx]!
 
-        case (
-        | entry <: @->(_KVBA(K, V)) |
+        case entry <: (
+        | @->(_KVBA(K, V)) |
           if H.equal(key, entry.key) (
             result_idx = idx
             found = True
             error! // TODO: use early return instead of error!
           )
-        | entry <: _MapEmpty |
+        | _MapEmpty |
           if (idx_del > mask) (
             result_idx = idx
           |
@@ -191,7 +191,7 @@
           )
           found = False
           error!
-        | entry <: _MapDeleted |
+        | _MapDeleted |
           if (idx_del > mask) (
             idx_del = idx
           )

--- a/packages/http/server/request_parser.mare
+++ b/packages/http/server/request_parser.mare
@@ -29,41 +29,41 @@
     :yields RequestToken
     try (
       while (@_state != _RequestAtEnd) (
-        @_state = case (
-        | @_state == _RequestAtStart |
+        @_state = case @_state == (
+        | _RequestAtStart |
           _RequestAtMethod
-        | @_state == _RequestAtMethod |
+        | _RequestAtMethod |
           stream.advance_while! -> (byte | byte != ' ')
           yield RequestTokenMethod
           stream.advance!(1) // consume the space
           _RequestAtUri
-        | @_state == _RequestAtUri |
+        | _RequestAtUri |
           stream.advance_while! -> (byte | byte != ' ')
           yield RequestTokenUri
           stream.advance!(1) // consume the space
           _RequestAtVersionString
-        | @_state == _RequestAtVersionString |
+        | _RequestAtVersionString |
           stream.advance_while! -> (byte | byte != '\r')
           if (stream.bytes_ahead < 2) error! // ensure the LF byte is ready too
           yield RequestTokenVersionString
           stream.advance!(2) // consume the CRLF
           _RequestAtHeaderLineMaybe
-        | @_state == _RequestAtHeaderLineMaybe |
+        | _RequestAtHeaderLineMaybe |
           if (stream.peek_byte! == '\r' && stream.peek_byte!(1) == '\n') (
             stream.advance!(2)
             _RequestAtEnd
           |
             _RequestAtHeaderName
           )
-        | @_state == _RequestAtHeaderName |
+        | _RequestAtHeaderName |
           stream.advance_while! -> (byte | byte != ':')
           yield RequestTokenHeaderName
           stream.advance!(1) // consume the colon
           _RequestAtHeaderSpacing
-        | @_state == _RequestAtHeaderSpacing |
+        | _RequestAtHeaderSpacing |
           stream.advance_while! -> (byte | byte == ' ' || byte == '\t')
           _RequestAtHeaderValue
-        | @_state == _RequestAtHeaderValue |
+        | _RequestAtHeaderValue |
           stream.advance_while! -> (byte | byte != '\r')
           if (stream.bytes_ahead < 2) error! // ensure the LF byte is ready too
           yield RequestTokenHeaderValue

--- a/packages/http/server/request_reader.mare
+++ b/packages/http/server/request_reader.mare
@@ -59,8 +59,8 @@
 
   :fun ref read!(stream ByteStreamReader) Request'iso
     @_parser.parse!(stream) -> (token |
-      case (
-      | token == RequestTokenMethod |
+      case token == (
+      | RequestTokenMethod |
         try (
           @_request.method = @_supported_methods.find! -> (method |
             stream.is_token_equal_to(method)
@@ -69,14 +69,14 @@
           @_error = RequestErrorUnsupportedMethod
           error!
         )
-      | token == RequestTokenUri |
+      | RequestTokenUri |
         if (stream.token_byte_size <= @_max_uri_byte_size) (
           @_request.uri_string = stream.token_as_string
         |
           @_error = RequestErrorURITooLong
           error!
         )
-      | token == RequestTokenVersionString |
+      | RequestTokenVersionString |
         if stream.is_token_equal_to(b"HTTP/1.1") (
           // Version is okay - no action needed
           // TODO: Accept HTTP/1.0 and change `Connection` header behavior
@@ -84,7 +84,7 @@
           @_error = RequestErrorUnsupportedVersion
           error!
         )
-      | token == RequestTokenHeaderName |
+      | RequestTokenHeaderName |
         try (
           @_next_header = @_standard_headers.find! -> (name |
             stream.is_token_ascii_lowercase_equal_to(name)
@@ -96,7 +96,7 @@
         |
           "" // ignore all other header names
         ))
-      | token == RequestTokenHeaderValue |
+      | RequestTokenHeaderValue |
         case (
         // We can safely use `is` here because we have ensured that each
         // such next_header we may compare against here is the "stringtabbed"

--- a/packages/http/server/test/request_reader_spec.mare
+++ b/packages/http/server/test/request_reader_spec.mare
@@ -166,12 +166,12 @@
     if (finished_too_soon) (
       // If we finished too soon, there was either an error to show,
       // or the parser failed to consume all of the chunks before finishing.
-      case (
-      | saw_error == RequestErrorNone |
+      case saw_error == (
+      | RequestErrorNone |
         @env.err.write("\nexpected "), @env.err.write(Inspect[source_chunks])
         @env.err.print(" to parse fully, but it finished too soon")
         False
-      | saw_error == expected_error |
+      | expected_error |
         True
       |
         @env.err.write("\nexpected "), @env.err.write(Inspect[source_chunks])

--- a/packages/json/json_parser.mare
+++ b/packages/json/json_parser.mare
@@ -52,11 +52,11 @@
     keep_going = True
     while (keep_going && @_has_next) (
       peeked = @_peek_softly
-      case (
-      | peeked == ' '  | @_advance
-      | peeked == '\r' | @_advance
-      | peeked == '\t' | @_advance
-      | peeked == '\n' | @_advance
+      case peeked == (
+      | ' '  | @_advance
+      | '\r' | @_advance
+      | '\t' | @_advance
+      | '\n' | @_advance
       | keep_going = False
       )
     )
@@ -94,9 +94,9 @@
     @_skip_whitespace
     @_pre_token
     peeked = @_peek!
-    case (
-    | peeked == 't' | @_advance, @_eat!('r'), @_eat!('u'), @_eat!('e'),              True
-    | peeked == 'f' | @_advance, @_eat!('a'), @_eat!('l'), @_eat!('s'), @_eat!('e'), False
+    case peeked == (
+    | 't' | @_advance, @_eat!('r'), @_eat!('u'), @_eat!('e'),              True
+    | 'f' | @_advance, @_eat!('a'), @_eat!('l'), @_eat!('s'), @_eat!('e'), False
     | error!
     )
 
@@ -116,9 +116,9 @@
         @_skip_whitespace
         @_pre_token // prepare for possible array end token
         next = @_next!
-        case (
-        | next == ',' | @_skip_whitespace
-        | next == ']' | keep_going = False
+        case next == (
+        | ',' | @_skip_whitespace
+        | ']' | keep_going = False
         | @_rewind, error!
         )
       )
@@ -146,9 +146,9 @@
         @_skip_whitespace
         @_pre_token // prepare for possible array end token
         next = @_next!
-        case (
-        | next == ',' | @_skip_whitespace
-        | next == ']' | keep_going = False
+        case next == (
+        | ',' | @_skip_whitespace
+        | ']' | keep_going = False
         | @_rewind, error!
         )
       )
@@ -175,9 +175,9 @@
         @_skip_whitespace
         @_pre_token, yield JsonTokenPairPost
         next = @_next!
-        case (
-        | next == ',' | @_skip_whitespace
-        | next == '}' | keep_going = False
+        case next == (
+        | ',' | @_skip_whitespace
+        | '}' | keep_going = False
         | @_rewind, error!
         )
       )
@@ -208,9 +208,9 @@
 
         @_skip_whitespace
         next = @_next!
-        case (
-        | next == ',' | @_skip_whitespace
-        | next == '}' | keep_going = False
+        case next == (
+        | ',' | @_skip_whitespace
+        | '}' | keep_going = False
         | @_rewind, error!
         )
       )
@@ -241,9 +241,9 @@
       @_advance
       peeked = @_peek!
       exp_negative =
-        case (
-        | peeked == '+' | @_advance, False
-        | peeked == '-' | @_advance, True
+        case peeked == (
+        | '+' | @_advance, False
+        | '-' | @_advance, True
         | False
         )
       exp = @_read_number_digits!
@@ -283,9 +283,9 @@
     keep_going = True
     while keep_going (
       next = @_next!
-      case (
-      | next == '"'  | keep_going = False
-      | next == '\\' | buf = @_push_escape_seq!(buf)
+      case next == (
+      | '"'  | keep_going = False
+      | '\\' | buf = @_push_escape_seq!(buf)
       | buf.push_byte(next)
       )
     )
@@ -303,16 +303,16 @@
 
   :fun ref _push_escape_seq!(buf String'ref) String'ref
     next = @_next!
-    case (
-    | next == '"'  | buf.push_byte('"')
-    | next == '\\' | buf.push_byte('\\')
-    | next == '/'  | buf.push_byte('/')
-    | next == 'b'  | buf.push_byte(0x08)
-    | next == 't'  | buf.push_byte(0x09)
-    | next == 'n'  | buf.push_byte(0x0a)
-    | next == 'f'  | buf.push_byte(0x0c)
-    | next == 'r'  | buf.push_byte(0x0d)
-    | next == 'u'  | buf.push_utf8(@_read_unicode_seq!)
+    case next == (
+    | '"'  | buf.push_byte('"')
+    | '\\' | buf.push_byte('\\')
+    | '/'  | buf.push_byte('/')
+    | 'b'  | buf.push_byte(0x08)
+    | 't'  | buf.push_byte(0x09)
+    | 'n'  | buf.push_byte(0x0a)
+    | 'f'  | buf.push_byte(0x0c)
+    | 'r'  | buf.push_byte(0x0d)
+    | 'u'  | buf.push_utf8(@_read_unicode_seq!)
     | error!
     )
     --buf

--- a/packages/json/test/json_reader_spec.mare
+++ b/packages/json/test/json_reader_spec.mare
@@ -5,9 +5,9 @@
   :prop admin Bool: False
   :fun ref from_json!(read JsonReader)
     read.each_in_object! -> (key |
-      case (
-      | key == "name" | try (@name = read.string!)
-      | key == "admin" | try (@admin = read.bool!)
+      case key == (
+      | "name"  | try (@name = read.string!)
+      | "admin" | try (@admin = read.bool!)
       | read.unexpected_key
       )
     )

--- a/packages/net/tcp.mare
+++ b/packages/net/tcp.mare
@@ -39,12 +39,12 @@
   :fun ref react(event CPointer(AsioEvent), flags U32, arg U32) @
     :yields IOAction
     @io.react(event, flags, arg) -> (action |
-      case (
-      | action == IOActionClosed |
+      case action == (
+      | IOActionClosed |
         try @listen.as!(TCPListener)._conn_closed
 
       // TODO: complete writes, pending writes logic from Pony
-      // | action == IOActionWrite |
+      // | IOActionWrite |
       //   ...
       )
       yield action

--- a/packages/net/tcp_listener.mare
+++ b/packages/net/tcp_listener.mare
@@ -77,10 +77,10 @@
         try (
           while (@_limit == 0 || @_count < @_limit) (
             conn_fd = LibPonyOS.pony_os_accept(@_event)
-            case (
-            | conn_fd ==  0 | error! // EWOULDBLOCK, don't try again
-            | conn_fd == -1 | None   // Some other error, so we can try again
-            |                 @_spawn(conn_fd)
+            case conn_fd == (
+            |  0 | error! // EWOULDBLOCK, don't try again
+            | -1 | None   // Some other error, so we can try again
+            |      @_spawn(conn_fd)
             )
           )
           @_paused = True

--- a/packages/net/test/tcp_spec.mare
+++ b/packages/net/test/tcp_spec.mare
@@ -30,8 +30,8 @@
     @env.err.print("[Echoer] Accepted")
 
   :fun ref _io_react(action IOAction)
-    case (
-    | action == IOActionRead |
+    case action == (
+    | IOActionRead |
       @io.pending_reads -> (bytes_available |
         @io.read_stream.advance_to_end
         bytes val = @io.read_stream.extract_token
@@ -40,7 +40,7 @@
         @io.write(bytes.clone)
         @io.close
       )
-    | action == IOActionClosed |
+    | IOActionClosed |
       @env.err.print("[Echoer] Closed")
       try @io.listen.as!(TCPListener).dispose
     )
@@ -62,16 +62,16 @@
     )
 
   :fun ref _io_react(action IOAction)
-    case (
-    | action == IOActionOpened |
+    case action == (
+    | IOActionOpened |
       @env.err.print("[EchoClient] Connected")
       @io.write(b"Hello, World!")
 
-    | action == IOActionOpenFailed |
+    | IOActionOpenFailed |
       @env.err.print("[EchoClient] Failed to connect:")
       @env.err.print(@io.connect_error.name)
 
-    | action == IOActionRead |
+    | IOActionRead |
       @io.pending_reads -> (bytes_available |
         if (bytes_available >= b"Hello, World!".size) (
           @io.read_stream.advance_to_end
@@ -81,7 +81,7 @@
         )
       )
 
-    | action == IOActionClosed |
+    | IOActionClosed |
       @env.err.print("[EchoClient] Closed")
       try @io.listen.as!(TCPListener).dispose
     )

--- a/packages/regex/_parser.mare
+++ b/packages/regex/_parser.mare
@@ -10,22 +10,22 @@
     input.each_byte -> (byte |
       if is_in_escape_sequence (
         is_in_escape_sequence = False
-        pattern = case (
-        | byte == 'd' | pattern.concat(@_builtin_class_digit)
-        | byte == 'w' | pattern.concat(@_builtin_class_word)
+        pattern = case byte == (
+        | 'd' | pattern.concat(@_builtin_class_digit)
+        | 'w' | pattern.concat(@_builtin_class_word)
         |
           // TODO: proper UTF-8 support here
           char = PatternCharacter.new(byte, 0, 0, 0)
           pattern.concat(char)
         )
       |
-        pattern = case (
-        | byte == '\\' | is_in_escape_sequence = True, pattern
-        | byte == '.' | pattern.concat(PatternAnyByte.new) // TODO: proper UTF-8
-        | byte == '?' | pattern.with_question
-        | byte == '*' | pattern.with_star
-        | byte == '+' | pattern.with_plus
-        | byte == '|' | choice.children.push(pattern), pattern = PatternNone.new
+        pattern = case byte == (
+        | '\\' | is_in_escape_sequence = True, pattern
+        | '.'  | pattern.concat(PatternAnyByte.new) // TODO: proper UTF-8
+        | '?'  | pattern.with_question
+        | '*'  | pattern.with_star
+        | '+'  | pattern.with_plus
+        | '|'  | choice.children.push(pattern), pattern = PatternNone.new
         |
           // TODO: proper UTF-8 support here
           char = PatternCharacter.new(byte, 0, 0, 0)

--- a/packages/regex/_program.mare
+++ b/packages/regex/_program.mare
@@ -43,20 +43,20 @@
     @
 
   :fun ref _pattern(pattern Pattern)
-    case (
-    | pattern <: PatternAnyByte |
+    case pattern <: (
+    | PatternAnyByte |
       @_op(OpAnyByte)
 
-    | pattern <: PatternByte |
+    | PatternByte |
       @_op(OpByte)
       @_byte(pattern.byte)
 
-    | pattern <: PatternByteRange |
+    | PatternByteRange |
       @_op(OpByteRange)
       @_byte(pattern.low)
       @_byte(pattern.high)
 
-    | pattern <: PatternCharacter |
+    | PatternCharacter |
       pattern.each_byte -> (byte |
         if (byte < Op.min_op) (
           @_byte(byte)
@@ -66,10 +66,10 @@
         )
       )
 
-    | pattern <: PatternSequence |
+    | PatternSequence |
       pattern.children.each -> (child | @_pattern(child))
 
-    | pattern <: PatternOptional |
+    | PatternOptional |
       @_op(OpSplit)
       primary_addr = @_later_addr
       secondary_addr = @_later_addr
@@ -82,7 +82,7 @@
 
       try @_store_current_cursor_at!(absent_addr)
 
-    | pattern <: PatternZeroOrMore |
+    | PatternZeroOrMore |
       start_cursor = @_cursor
       @_op(OpSplit)
       primary_addr = @_later_addr
@@ -99,7 +99,7 @@
 
       try @_store_current_cursor_at!(absent_addr)
 
-    | pattern <: PatternOneOrMore |
+    | PatternOneOrMore |
       start_cursor = @_cursor
       @_pattern(pattern.child)
 
@@ -114,7 +114,7 @@
         try @_store_current_cursor_at!(after_addr)
       )
 
-    | pattern <: PatternChoice |
+    | PatternChoice |
       if (pattern.children.size == 2) (
         @_op(OpSplit)
         primary_addr = @_later_addr

--- a/packages/time/time.mare
+++ b/packages/time/time.mare
@@ -17,14 +17,14 @@
   :member Sunday: 7
 
   :fun non from_value(value U8)
-    case (
-      | value == 1 | Monday
-      | value == 2 | Tuesday
-      | value == 3 | Wednesday
-      | value == 4 | Thursday
-      | value == 5 | Friday
-      | value == 6 | Saturday
-      | value == 7 | Sunday
+    case value == (
+      | 1 | Monday
+      | 2 | Tuesday
+      | 3 | Wednesday
+      | 4 | Thursday
+      | 5 | Friday
+      | 6 | Saturday
+      | 7 | Sunday
       | NoDay
     )
 
@@ -207,19 +207,19 @@
 
   :: Returns the number of days in the given month of the given year.
   :fun non _days_in_month(month U8, year) U8
-    case (
-    | month ==  1 | 31 // January
-    | month ==  2 | if @_is_leap_year(year) (29 | 28) // Feb.
-    | month ==  3 | 31 // March
-    | month ==  4 | 30 // April
-    | month ==  5 | 31 // May
-    | month ==  6 | 30 // June
-    | month ==  7 | 31 // July
-    | month ==  8 | 31 // August
-    | month ==  9 | 30 // September
-    | month == 10 | 31 // October
-    | month == 11 | 30 // November
-    | month == 12 | 31 // December
+    case month == (
+    |  1 | 31 // January
+    |  2 | if @_is_leap_year(year) (29 | 28) // Feb.
+    |  3 | 31 // March
+    |  4 | 30 // April
+    |  5 | 31 // May
+    |  6 | 30 // June
+    |  7 | 31 // July
+    |  8 | 31 // August
+    |  9 | 30 // September
+    | 10 | 31 // October
+    | 11 | 30 // November
+    | 12 | 31 // December
     | 0 // months that don't exist have zero days
     )
 

--- a/src/prelude/inspect.mare
+++ b/src/prelude/inspect.mare
@@ -25,14 +25,14 @@
     InspectLibC.puts(@[input].cstring)
 
   :fun into(output String'iso, input Any'box) String'iso // TODO: use `box` instead of `Any'box` // TODO: use something like Crystal IO instead of String?
-    case (
-    | input <: _InspectCustom | input.inspect_into(--output)
-    | input <: _InspectEnum | output << input.member_name, --output
-    | input <: U8'box    | @into(--output, input.u64) // TODO: unify into one integer clause?
-    | input <: U16'box   | @into(--output, input.u64) // TODO: unify into one integer clause?
-    | input <: U32'box   | @into(--output, input.u64) // TODO: unify into one integer clause?
-    | input <: USize'box | @into(--output, input.u64) // TODO: unify into one integer clause?
-    | input <: U64'box   |                            // TODO: unify into one integer clause?
+    case input <: (
+    | _InspectCustom | input.inspect_into(--output)
+    | _InspectEnum | output << input.member_name, --output
+    | U8'box    | @into(--output, input.u64) // TODO: unify into one integer clause?
+    | U16'box   | @into(--output, input.u64) // TODO: unify into one integer clause?
+    | U32'box   | @into(--output, input.u64) // TODO: unify into one integer clause?
+    | USize'box | @into(--output, input.u64) // TODO: unify into one integer clause?
+    | U64'box   |                            // TODO: unify into one integer clause?
       number = input.u64
       digits Array(U8) = []
       while (number > 0) (
@@ -42,22 +42,22 @@
       digits.reverse_each -> (digit | output.push_byte(digit), None) // TODO: None should not be needed here
       if (digits.size == 0) (output.push_byte('0'))
       --output
-    | input <: I8'box    | @into(--output, input.i64) // TODO: unify into one integer clause?
-    | input <: I16'box   | @into(--output, input.i64) // TODO: unify into one integer clause?
-    | input <: I32'box   | @into(--output, input.i64) // TODO: unify into one integer clause?
-    | input <: ISize'box | @into(--output, input.i64) // TODO: unify into one integer clause?
-    | input <: I64'box   |                            // TODO: unify into one integer clause?
+    | I8'box    | @into(--output, input.i64) // TODO: unify into one integer clause?
+    | I16'box   | @into(--output, input.i64) // TODO: unify into one integer clause?
+    | I32'box   | @into(--output, input.i64) // TODO: unify into one integer clause?
+    | ISize'box | @into(--output, input.i64) // TODO: unify into one integer clause?
+    | I64'box   |                            // TODO: unify into one integer clause?
       number = input.i64
       positive = if (number >= 0) (number | output.push_byte('-'), number.abs)
       @into(--output, positive.u64)
-    | input <: F32'box | @_inspect_float_into(--output, input.f64) // TODO: unify into one float clause?
-    | input <: F64'box | @_inspect_float_into(--output, input.f64) // TODO: unify into one float clause?
-    | input <: String'box |
+    | F32'box | @_inspect_float_into(--output, input.f64) // TODO: unify into one float clause?
+    | F64'box | @_inspect_float_into(--output, input.f64) // TODO: unify into one float clause?
+    | String'box |
       output.push_byte('"')
       output << input.clone // TODO: show some characters as escaped.
       output.push_byte('"')
       --output
-    | input <: _InspectEach |
+    | _InspectEach |
       output.push_byte('[')
       index USize = 0
       while (index < input.size) (

--- a/src/prelude/string.mare
+++ b/src/prelude/string.mare
@@ -438,34 +438,34 @@
 :primitive _UTF8Encoder
   :fun encode(value U32)
     :yields (USize, U8, U8, U8, U8)
-    case (
-    | value < 0x80 |
+    case value < (
+    | 0x80 |
       yield (1, value.u8, 0, 0, 0)
-    | value < 0x800 |
+    | 0x800 |
       yield (2
         value.bit_shr(6).bit_or(0xC0).u8
         value.bit_and(0x3F).bit_or(0x80).u8
         0
         0
       )
-    | value < 0xD800 |
+    | 0xD800 |
       yield (3
         value.bit_shr(12).bit_or(0xE0).u8
         value.bit_shr(6).bit_and(0x3F).bit_or(0x80).u8
         value.bit_and(0x3F).bit_or(0x80).u8
         0
       )
-    | value < 0xE000 |
+    | 0xE000 |
       // UTF-16 surrogate pairs are not allowed.
       yield (3, 0xEF, 0xBF, 0xBD, 0)
-    | value < 0x10000 |
+    | 0x10000 |
       yield (3
         value.bit_shr(12).bit_or(0xE0).u8
         value.bit_shr(6).bit_and(0x3F).bit_or(0x80).u8
         value.bit_and(0x3F).bit_or(0x80).u8
         0
       )
-    | value < 0x110000 |
+    | 0x110000 |
       yield (4
         value.bit_shr(18).bit_or(0xF0).u8
         value.bit_shr(12).bit_and(0x3F).bit_or(0x80).u8


### PR DESCRIPTION
This PR is a follow up to #71. I only updated the instances of `case` where the identifier and operator were *always* the same across the `case` statement.

I also learned that the `is` operator is not supported by the new syntax, likely because it's not parsed as a `Relate` node in the AST. I'll chase that one down in a different PR.

This PR also adds a bit of documentation about the alternative syntax in `docs/intro-vs-pony.md`