### PR TITLE
Skip examples with no assertions

### DIFF
--- a/packages/spec/spec_reporter.mare
+++ b/packages/spec/spec_reporter.mare
@@ -4,7 +4,7 @@
   :fun ref spec_began(spec String): None
   :fun ref spec_ended(spec String): None
   :fun ref example_began(spec String, example String): None
-  :fun ref example_ended(spec String, example String): None
+  :fun ref example_ended(spec String, example String, skip Bool): None
   :fun ref event(spec String, example String, event SpecEventAssert): None
 
 :class SpecReporterDots
@@ -44,8 +44,8 @@
     @env.err.write("  ")
     @env.err.write(example)
 
-  :fun ref example_ended(spec String, example String)
-    @env.err.print(" OK")
+  :fun ref example_ended(spec String, example String, skip Bool)
+    if (skip) (@env.err.print(" SKIP") | @env.err.print(" OK"))
 
   :fun ref event(spec String, example String, event SpecEventAssert)
     if event.success (
@@ -68,7 +68,7 @@
   :fun ref spec_began(spec String): @_changed
   :fun ref spec_ended(spec String): @_changed
   :fun ref example_began(spec String, example String): @_changed
-  :fun ref example_ended(spec String, example String): @_changed
+  :fun ref example_ended(spec String, example String, skip Bool): @_changed
   :fun ref event(spec String, example String, event SpecEventAssert): @_changed
 
   :fun ref _changed None // TODO: be able to infer return type for maybe-recursive functions
@@ -131,7 +131,8 @@
 
       // If the example has finished, but has not yet been reported, report now.
       if (example_status.ended && example_status.reported.not) (
-        @inner.example_ended(@current_spec, @current_example)
+        skip = example_status.events.size == 0
+        @inner.example_ended(@current_spec, @current_example, skip)
         example_status.reported = True
 
         // Since we've finished reporting this example, look to pick up another.

--- a/packages/spec/specs.mare
+++ b/packages/spec/specs.mare
@@ -65,7 +65,8 @@
         @spec_ended(spec)
       )
 
-      @reporter.example_ended(spec, example)
+      skip = example_status.events.size == 0
+      @reporter.example_ended(spec, example, skip)
     |
       Specs._bug(@env, "example_ended before the example_began")
     )


### PR DESCRIPTION
This is so we can leave `:it "example"` blocks hanging with no tests to be implemented later, and see that they were skipped when running the specs:

```
ResponseBuilder
  builds 1xx responses.. OK
  builds 3xx responses SKIP
  builds 2xx responses SKIP
  builds 4xx responses SKIP
  builds 5xx responses SKIP
  can add headers. OK
  can write a body. OK
```