### PR TITLE
Support building on FreeBSD

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,30 @@
+# Building mare from source
+
+## FreeBSD
+
+You need to build Pony first (please also consult Pony's documentation):
+
+```sh
+sudo pkg install -y cmake gmake libunwind git
+
+git clone https://github.com/ponylang/ponyc
+cd ponyc
+export CC=clang10
+export CXX=clang++10
+export CMAKE_C_FLAGS=-I/usr/local/include
+export CMAKE_CXX_FLAGS=-I/usr/local/include
+gmake libs
+gmake configure lto=yes runtime-bitcode=yes
+gmake build
+sudo cp build/release/libponyrt.bc /usr/local/lib
+```
+
+We only need file `libponyrt.bc`. Either copy it to a system library location,
+or set `MARE_PONYRT_BC_PATH` to the directory where it can be found.
+
+Then build `mare`:
+
+```sh
+crystal build main.cr
+# sudo cp ./main /usr/local/bin/mare
+```

--- a/main.cr
+++ b/main.cr
@@ -16,6 +16,7 @@ module Mare
       option "--print-perf", desc: "Print compiler performance info", type: Bool, default: false
       option "-o NAME", "--output=NAME", desc: "Name of the output binary"
       option "-p NAME", "--pass=NAME", desc: "Name of the compiler pass to target"
+      option "--target=TARGET", desc: "Target triple"
       run do |opts, args|
         options = Mare::Compiler::CompilerOptions.new(
           release: opts.release,
@@ -25,6 +26,7 @@ module Mare
         )
         options.binary_name = opts.output.not_nil! if opts.output
         options.target_pass = Mare::Compiler.pass_symbol(opts.pass) if opts.pass
+        options.target = Mare::Compiler::Target.new(opts.target.not_nil!) if opts.target
         Cli.compile options, opts.backtrace
       end
       sub "server" do

--- a/main.cr
+++ b/main.cr
@@ -16,7 +16,6 @@ module Mare
       option "--print-perf", desc: "Print compiler performance info", type: Bool, default: false
       option "-o NAME", "--output=NAME", desc: "Name of the output binary"
       option "-p NAME", "--pass=NAME", desc: "Name of the compiler pass to target"
-      option "--target=TARGET", desc: "Target triple"
       run do |opts, args|
         options = Mare::Compiler::CompilerOptions.new(
           release: opts.release,
@@ -26,7 +25,6 @@ module Mare
         )
         options.binary_name = opts.output.not_nil! if opts.output
         options.target_pass = Mare::Compiler.pass_symbol(opts.pass) if opts.pass
-        options.target = Mare::Compiler::Target.new(opts.target.not_nil!) if opts.target
         Cli.compile options, opts.backtrace
       end
       sub "server" do

--- a/src/mare/compiler.cr
+++ b/src/mare/compiler.cr
@@ -8,7 +8,6 @@ class Mare::Compiler
     property print_perf
     property binary_name
     property target_pass : Symbol?
-    property target : Target?
 
     DEFAULT_BINARY_NAME = "main"
 
@@ -19,7 +18,6 @@ class Mare::Compiler
       @print_perf = false,
       @binary_name = DEFAULT_BINARY_NAME,
       @target_pass = nil,
-      @target = nil,
     )
     end
   end

--- a/src/mare/compiler.cr
+++ b/src/mare/compiler.cr
@@ -8,6 +8,7 @@ class Mare::Compiler
     property print_perf
     property binary_name
     property target_pass : Symbol?
+    property target : Target?
 
     DEFAULT_BINARY_NAME = "main"
 
@@ -17,7 +18,8 @@ class Mare::Compiler
       @print_ir = false,
       @print_perf = false,
       @binary_name = DEFAULT_BINARY_NAME,
-      @target_pass = nil
+      @target_pass = nil,
+      @target = nil,
     )
     end
   end

--- a/src/mare/compiler/binary.cr
+++ b/src/mare/compiler/binary.cr
@@ -30,7 +30,7 @@ class Mare::Compiler::Binary
     machine = ctx.code_gen.target_machine
     mod = ctx.code_gen.mod
 
-    target = ctx.options.target
+    target = Target.new(machine.triple)
     ponyrt_bc_path = find_libponyrt_bc(PONYRT_BC_PATH) || raise "libponyrt.bc not found"
 
     ponyrt_bc = LLVM::MemoryBuffer.from_file(ponyrt_bc_path)
@@ -44,7 +44,7 @@ class Mare::Compiler::Binary
 
     machine.emit_obj_to_file(mod, obj_filename)
 
-    link_args = if target && target.freebsd?
+    link_args = if target.freebsd?
                   %w{clang
                     -fuse-ld=lld -static -fpic -flto=thin
                     -lc -pthread -ldl -lexecinfo -lelf

--- a/src/mare/compiler/target.cr
+++ b/src/mare/compiler/target.cr
@@ -1,9 +1,4 @@
-# TODO: Bring in "crystal/src/compiler/crystal/codegen/target.cr"
-class Mare::Compiler::Target
-  def initialize(@target_triple : String)
-  end
+require "compiler/crystal/codegen/target"
 
-  def freebsd?
-    @target_triple.downcase.split("-").any? { |part| part.starts_with?("freebsd") }
-  end
+class Mare::Compiler::Target < Crystal::Codegen::Target
 end

--- a/src/mare/compiler/target.cr
+++ b/src/mare/compiler/target.cr
@@ -1,0 +1,9 @@
+# TODO: Bring in "crystal/src/compiler/crystal/codegen/target.cr"
+class Mare::Compiler::Target
+  def initialize(@target_triple : String)
+  end
+
+  def freebsd?
+    @target_triple.downcase.split("-").any? { |part| part.starts_with?("freebsd") }
+  end
+end


### PR DESCRIPTION
With this in place I can compile Mare programs on FreeBSD with

    ./mare --target=x86_64-unknown-freebsd hw.mare

given a libponyrt.bc exists at /usr/local/lib.

TODO:

* There should always be a target defined. `Target?` -> `Target`

* Reuse `Target` class from Crystal compiler?