### PR TITLE
Fix http example on FreeBSD

### DIFF
--- a/examples/http/main.mare
+++ b/examples/http/main.mare
@@ -35,8 +35,8 @@
     @io = TCPConnectionEngine.accept(@, listen, --ticket)
 
   :fun ref _io_react(action IOAction)
-    case (
-    | action == IOActionRead |
+    case action == (
+    | IOActionRead |
       @io.pending_reads -> (data |
         try (
           request = @reader.read!(@io.read_stream)
@@ -51,5 +51,7 @@
           @io.flush
         )
       )
+    | IOActionWrite |
+      @io.flush
     )
     @


### PR DESCRIPTION
* The first `@io.flush` might not write out the whole request.

* Also try to flush when the socket is writable (`state == IOActionWrite`)