### PR TITLE
Expose byteorder and methods to read little/big endian integers

### DIFF
--- a/packages/net/net_address.mare
+++ b/packages/net/net_address.mare
@@ -21,7 +21,7 @@
   :fun scope:     LibC.ntohl(@_scope) // (converted to host byte order)
   :fun ipv4_addr: LibC.ntohl(@_ipv4) // (converted to host byte order)
   // TODO: ipv6_addr (needs tuple return value)
-  // TODO: family (needs Platform.bidendian)
+  // TODO: family (needs Platform.big_endian)
 
   :fun "=="(other NetAddress'box)
     @_family == other._family

--- a/spec/mare/prelude/bytes_spec.mare
+++ b/spec/mare/prelude/bytes_spec.mare
@@ -367,6 +367,35 @@
     @assert = try (data.write_native_u32!(10, 0x12345678), False | True)
     @assert = try (data.write_native_u64!(6, 0xfedcba9876543210), False | True)
 
+  :it "reads big and little endian integer types at specific offsets"
+    data = Bytes.new
+
+    data.push(0x01)
+    data.push(0x23)
+    data.push(0x45)
+    data.push(0x67)
+
+    data.push(0x89)
+    data.push(0xAB)
+    data.push(0xCD)
+    data.push(0xEF)
+
+    data.push(0x01)
+
+    @assert = try (data.read_be_u16!(0) == 0x0123 | False)
+    @assert = try (data.read_be_u16!(1) == 0x2345 | False)
+    @assert = try (data.read_be_u32!(0) == 0x01234567 | False)
+    @assert = try (data.read_be_u32!(1) == 0x23456789 | False)
+    @assert = try (data.read_be_u64!(0) == 0x0123456789ABCDEF | False)
+    @assert = try (data.read_be_u64!(1) == 0x23456789ABCDEF01 | False)
+
+    @assert = try (data.read_le_u16!(0) == 0x2301 | False)
+    @assert = try (data.read_le_u16!(1) == 0x4523 | False)
+    @assert = try (data.read_le_u32!(0) == 0x67452301 | False)
+    @assert = try (data.read_le_u32!(1) == 0x89674523 | False)
+    @assert = try (data.read_le_u64!(0) == 0xEFCDAB8967452301 | False)
+    @assert = try (data.read_le_u64!(1) == 0x01EFCDAB89674523 | False)
+
   :it "joins an array of bytes"
     @assert = Bytes.join([
       b"foo"

--- a/spec/mare/prelude/numeric_spec.mare
+++ b/spec/mare/prelude/numeric_spec.mare
@@ -255,6 +255,7 @@
     @assert = U8[18].invert         == 0b11101101
     @assert = U8[18].reverse_bits   == 0b01001000
     @assert = U8[18].swap_bytes     == 18
+    @assert = U16[0x1234].swap_bytes == 0x3412
     @assert = U32[66052].swap_bytes == 67240192
     @assert = U8[18].leading_zeros  == 3
     @assert = U8[18].trailing_zeros == 1

--- a/spec/mare/prelude/platform_spec.mare
+++ b/spec/mare/prelude/platform_spec.mare
@@ -9,3 +9,6 @@
       (if Platform.ilp32 (1 | 0)) +
       (if Platform.lp64  (1 | 0)) +
       (if Platform.llp64 (1 | 0))
+
+  :it "is either big or little endian"
+    @assert = Platform.big_endian == !Platform.little_endian

--- a/src/mare/compiler/code_gen.cr
+++ b/src/mare/compiler/code_gen.cr
@@ -923,6 +923,10 @@ class Mare::Compiler::CodeGen
         gen_bool(abi_size_of(@isize) == 4)
       when "lp64"
         gen_bool(abi_size_of(@isize) == 8)
+      when "big_endian"
+        gen_bool(@target_machine.data_layout.big_endian?)
+      when "little_endian"
+        gen_bool(@target_machine.data_layout.little_endian?)
       else
         raise NotImplementedError.new(gfunc.func.ident.value)
       end
@@ -1203,6 +1207,11 @@ class Mare::Compiler::CodeGen
         case bit_width_of(gtype)
         when 1, 8
           params[0]
+        when 16
+          op_func =
+            @mod.functions["llvm.bswap.i16"]? ||
+              @mod.functions.add("llvm.bswap.i16", [@i16], @i16)
+          @builder.call(op_func, [params[0]])
         when 32
           op_func =
             @mod.functions["llvm.bswap.i32"]? ||

--- a/src/mare/ext/llvm/lib_llvm.cr
+++ b/src/mare/ext/llvm/lib_llvm.cr
@@ -20,4 +20,11 @@ lib LibLLVM
   fun const_shl = LLVMConstShl(lhs : ValueRef, rhs : ValueRef) : ValueRef
   fun build_is_null = LLVMBuildIsNull(builder : BuilderRef, value : ValueRef, name : UInt8*) : ValueRef
   fun build_is_not_null = LLVMBuildIsNotNull(builder : BuilderRef, value : ValueRef, name : UInt8*) : ValueRef
+
+  enum ByteOrdering
+    BigEndian
+    LittleEndian
+  end
+
+  fun byte_order = LLVMByteOrder(TargetDataRef) : ByteOrdering
 end

--- a/src/mare/ext/llvm/target_data.cr
+++ b/src/mare/ext/llvm/target_data.cr
@@ -1,0 +1,9 @@
+struct LLVM::TargetData
+  def big_endian?
+    LibLLVM.byte_order(self) == LibLLVM::ByteOrdering::BigEndian
+  end
+
+  def little_endian?
+    LibLLVM.byte_order(self) == LibLLVM::ByteOrdering::LittleEndian
+  end
+end

--- a/src/prelude/bytes.mare
+++ b/src/prelude/bytes.mare
@@ -452,12 +452,43 @@
     @_space = offset
     --chopped
 
+  :: Read a U16 from the bytes at the given offset, with native byte order.
+  :: This is not suitable for protocols using a platform-independent byte order.
+  :: Raises an error if there aren't enough bytes at that offset to fill a U16.
+  :fun read_native_u16!(offset USize) U16
+    if ((offset + U16.byte_width.usize) > @_size) error!
+    CPointer(U16).from_usize(@_ptr._offset(offset).usize)._unsafe._get_at(0)
+
+  :: Read a U16 from the bytes at the given offset, with big endian byte order.
+  :: Raises an error if there aren't enough bytes at that offset to fill a U16.
+  :fun read_be_u16!(offset USize) U16
+    number = @read_native_u16!(offset)
+    if (Platform.big_endian) (number | number.swap_bytes)
+
+  :: Read a U16 from the bytes at the given offset, with little endian byte order.
+  :: Raises an error if there aren't enough bytes at that offset to fill a U16.
+  :fun read_le_u16!(offset USize) U16
+    number = @read_native_u16!(offset)
+    if (Platform.little_endian) (number | number.swap_bytes)
+
   :: Read a U32 from the bytes at the given offset, with native byte order.
   :: This is not suitable for protocols using a platform-independent byte order.
   :: Raises an error if there aren't enough bytes at that offset to fill a U32.
   :fun read_native_u32!(offset USize) U32
     if ((offset + U32.byte_width.usize) > @_size) error!
     CPointer(U32).from_usize(@_ptr._offset(offset).usize)._unsafe._get_at(0)
+
+  :: Read a U32 from the bytes at the given offset, with big endian byte order.
+  :: Raises an error if there aren't enough bytes at that offset to fill a U32.
+  :fun read_be_u32!(offset USize) U32
+    number = @read_native_u32!(offset)
+    if (Platform.big_endian) (number | number.swap_bytes)
+
+  :: Read a U32 from the bytes at the given offset, with little endian byte order.
+  :: Raises an error if there aren't enough bytes at that offset to fill a U32.
+  :fun read_le_u32!(offset USize) U32
+    number = @read_native_u32!(offset)
+    if (Platform.little_endian) (number | number.swap_bytes)
 
   :: Write a U32 as bytes starting at the given offset, in native byte order.
   :: This is not suitable for protocols using a platform-independent byte order.
@@ -484,6 +515,18 @@
   :fun read_native_u64!(offset USize) U64
     if ((offset + U64.byte_width.usize) > @_size) error!
     CPointer(U64).from_usize(@_ptr._offset(offset).usize)._unsafe._get_at(0)
+
+  :: Read a U64 from the bytes at the given offset, with big endian byte order.
+  :: Raises an error if there aren't enough bytes at that offset to fill a U64.
+  :fun read_be_u64!(offset USize) U64
+    number = @read_native_u64!(offset)
+    if (Platform.big_endian) (number | number.swap_bytes)
+
+  :: Read a U64 from the bytes at the given offset, with little endian byte order.
+  :: Raises an error if there aren't enough bytes at that offset to fill a U64.
+  :fun read_le_u64!(offset USize) U64
+    number = @read_native_u64!(offset)
+    if (Platform.little_endian) (number | number.swap_bytes)
 
   :: Write a U64 as bytes starting at the given offset, in native byte order.
   :: This is not suitable for protocols using a platform-independent byte order.

--- a/src/prelude/platform.mare
+++ b/src/prelude/platform.mare
@@ -3,3 +3,5 @@
   :const lp64 Bool: compiler intrinsic
   :const llp64 Bool: False // TODO: this is 65-but windows, instead of lp64
   :const windows Bool: False // TODO: True on windows
+  :const big_endian Bool: compiler intrinsic
+  :const little_endian Bool: compiler intrinsic


### PR DESCRIPTION
* Add boolean constants `Platform.big_endian` and `Platform.little_endian`

* Add method `U16#swap_bytes`

* Add methods `Bytes#read_{le,be}_{u16,u32,u64}`.