### PR TITLE
Fix case of using a single-identifier macro as an argument.

### DIFF
--- a/packages/json/json_parser.savi
+++ b/packages/json/json_parser.savi
@@ -275,11 +275,11 @@
     buf = String.new // TODO: don't allocate here - let the caller construct the string from escape tokens if/when they choose
     keep_going = True
     while keep_going (
-      next = @_next!
-      case next == (
+      byte = @_next!
+      case byte == (
       | '"'  | keep_going = False
       | '\\' | buf = @_push_escape_seq!(buf)
-      | buf.push_byte(next)
+      | buf.push_byte(byte)
       )
     )
     @last_string = buf.clone // TODO: skip clone here by skipping allocating in the first place - see above TODO comment

--- a/spec/compiler/macros/error_spec.cr
+++ b/spec/compiler/macros/error_spec.cr
@@ -15,6 +15,24 @@ describe Savi::Compiler::Macros do
         [:jump, "error", [:ident, "None"]]
     end
 
+    it "can be used as an argument" do
+      source = Savi::Source.new_example <<-SOURCE
+      :module Errors
+        :fun example!(cond)
+          Some.method(error!)
+      SOURCE
+
+      ctx = Savi.compiler.compile([source], :macros)
+      ctx.errors.should be_empty
+
+      func = ctx.namespace.find_func!(ctx, source, "Errors", "example!")
+      func.body.not_nil!.terms.first.to_a.should eq [:call,
+        [:ident, "Some"],
+        [:ident, "method"],
+        [:group, "(", [:jump, "error", [:ident, "None"]]],
+      ]
+    end
+
     it "can be conditional with `if`" do
       source = Savi::Source.new_example <<-SOURCE
       :module Errors

--- a/src/savi/compiler/macros.cr
+++ b/src/savi/compiler/macros.cr
@@ -589,7 +589,7 @@ class Savi::Compiler::Macros < Savi::AST::CopyOnMutateVisitor
     lhs = expr.lhs
     op = expr.op
     rhs = expr.rhs
-    
+
     # For the case where `rhs` is not a value expression, but rather a type expression:
     # `String`, `Array(String)` or `(String | None)`, we will compile into the
     # `Assert.type_relation` call.
@@ -651,9 +651,9 @@ class Savi::Compiler::Macros < Savi::AST::CopyOnMutateVisitor
     lhs = expr.lhs
     op = expr.op
     rhs = expr.rhs
-    
+
     # Use a hygienic local to refer to it multiple times without evaluating again.
-    local_lhs_name = AST::Identifier.new(next_local_name).from(lhs) 
+    local_lhs_name = AST::Identifier.new(next_local_name).from(lhs)
     local_lhs = AST::Relate.new(
       local_lhs_name,
       AST::Operator.new("=").from(lhs),
@@ -856,7 +856,6 @@ class Savi::Compiler::Macros < Savi::AST::CopyOnMutateVisitor
       when AST::Qualify
         @ignore_non_sequence_groups << node.group
       when AST::Call
-        node.args.try { |child| @ignore_non_sequence_groups << child }
         node.yield_params.try { |child| @ignore_non_sequence_groups << child }
       end
 


### PR DESCRIPTION
This was previously carved out as a special case, to facilitate
some code that used `next` as a variable name in JsonParser,
but now I'm just changing the variable name because carving out
that special case was a wrong/misguided thing to do.

There may be more things to figure out with single-identifier macros
to make things more clean/consistent, but this minimal change at
least resolves the immediate issue blocking @tonchis.