### PR TITLE
Mark as many LLVM functions as possible with private linkage.

### DIFF
--- a/src/savi/ext/llvm/basic_block_collection.cr
+++ b/src/savi/ext/llvm/basic_block_collection.cr
@@ -1,0 +1,7 @@
+require "./basic_block"
+
+struct LLVM::BasicBlockCollection
+  def empty?
+    !LibLLVM.get_first_basic_block(@function)
+  end
+end

--- a/src/savi/ext/llvm/lib_llvm.cr
+++ b/src/savi/ext/llvm/lib_llvm.cr
@@ -20,6 +20,8 @@ lib LibLLVM
   fun const_shl = LLVMConstShl(lhs : ValueRef, rhs : ValueRef) : ValueRef
   fun build_is_null = LLVMBuildIsNull(builder : BuilderRef, value : ValueRef, name : UInt8*) : ValueRef
   fun build_is_not_null = LLVMBuildIsNotNull(builder : BuilderRef, value : ValueRef, name : UInt8*) : ValueRef
+  fun get_dll_storage_class = LLVMGetDLLStorageClass(global : ValueRef) : LLVM::DLLStorageClass
+  fun set_dll_storage_class = LLVMSetDLLStorageClass(global : ValueRef, cls : LLVM::DLLStorageClass)
 
   enum ByteOrdering
     BigEndian

--- a/src/savi/ext/llvm/value_methods.cr
+++ b/src/savi/ext/llvm/value_methods.cr
@@ -7,6 +7,15 @@ module LLVM::ValueMethods
     LibLLVM.is_unnamed_addr(self) != 0
   end
 
+  def dll_storage_class : LLVM::DLLStorageClass
+    LibLLVM.get_dll_storage_class(self)
+  end
+
+  def dll_storage_class=(cls : LLVM::DLLStorageClass)
+    LibLLVM.set_dll_storage_class(self, cls)
+    cls
+  end
+
   def to_value
     Value.new to_unsafe
   end


### PR DESCRIPTION
We're not compiling a library, so we want to mark as many functions
as possible with private linkage, so LLVM can optimize them aggressively,
including inlining them, eliminating them if they are not used, and/or
marking them to use the fastest available calling convention.

Prior to this commit, the public runtime functions were all marked as
external, so they would miss out on optimizations if we don't do this.